### PR TITLE
Fetch multiple bytes if available

### DIFF
--- a/Plantower_PMS7003.cpp
+++ b/Plantower_PMS7003.cpp
@@ -38,7 +38,7 @@ void Plantower_PMS7003::updateFrame() {
     return;
   }
   dataReady = false;
-  if (serial->available()) {
+  while (serial->available() && bufferIndex < PMS7003_DATA_SIZE) {
     nextByte = serial->read();
     
     if (nextByte == 0x4d && lastByte == 0x42 ) {


### PR DESCRIPTION
Checks to see if multiple bytes are available to read and reads as many as are available, limited by the buffer size. As discussed in issue https://github.com/jmstriegel/Plantower_PMS7003/issues/2. 