### PR TITLE
fix for UNO R3

### DIFF
--- a/Plantower_PMS7003.cpp
+++ b/Plantower_PMS7003.cpp
@@ -17,12 +17,6 @@ Plantower_PMS7003::Plantower_PMS7003() {
   debug = false;
 }
 
-
-void Plantower_PMS7003::init() {
-  Serial1.begin(9600);
-  init(&Serial1);  
-}
-
 void Plantower_PMS7003::init(Stream *s) {
   dataReady = false;
   serial = s;

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Connecting the PMS7003 to a compatible 3.3v device requires 4 pins:
  - Connect microcontroller +5v VCC or USB to pin 1 (VCC).
  - Connect microcontroller GND to pin 3  (GND).
  - Connect microcontroller TX to pin 7 (RX).
- - Connect microcontroller RC to pin 9 (TX).
+ - Connect microcontroller RX to pin 9 (TX).
 
 ## Usage
 
@@ -94,6 +94,17 @@ Connecting the PMS7003 to a compatible 3.3v device requires 4 pins:
     }
 
 A full example can be found in pms_7003_test.ino.
+
+## Note on Uno R3 compatibility
+
+Uno R3 has a single serial port, so the existing example will not work for it - you cannot use USB
+and TX/RX pins simultaneously. To fix this and allow monitoring of the sensor data via USB during testing
+you can use [SoftwareSerial](https://docs.arduino.cc/learn/built-in-libraries/software-serial/) library.
+
+ - Connect microcontroller pin 3 to pin 7 (RX).
+ - Connect microcontroller pin 2 to pin 9 (TX).
+
+and use pms_7003_unoR3_test as an example.
 
 
 ## License

--- a/examples/pms_7003_unoR3_test/pms_7003_unoR3_test.ino
+++ b/examples/pms_7003_unoR3_test/pms_7003_unoR3_test.ino
@@ -1,0 +1,76 @@
+
+/*********************************************************************
+This is an example which demonstrates use of the Plantower PMS7003
+laser particle counter. This should also work the the PMS5003 sensor,
+as they share the same protocol.
+
+For more information about the PMS7003, see README.md.
+
+Written by Jason Striegel.
+BSD license. See license.txt for details.
+**********************************************************************/
+
+#include "Plantower_PMS7003.h"
+#include <SoftwareSerial.h>
+
+
+char output[256];
+Plantower_PMS7003 pms7003 = Plantower_PMS7003();
+SoftwareSerial serial1(2, 3); // RX, TX
+
+
+void setup()
+{
+  Serial.begin(9600);
+
+  serial1.begin(9600);
+  pms7003.init(&serial1);
+  //pms7003.debug = true;
+
+}
+ 
+void loop()
+{
+  pms7003.updateFrame();
+
+  if (pms7003.hasNewData()) {
+
+    sprintf(output, "\nSensor Version: %d    Error Code: %d\n",
+                  pms7003.getHWVersion(),
+                  pms7003.getErrorCode());
+    Serial.print(output);
+
+    sprintf(output, "    PM1.0 (ug/m3): %2d     [atmos: %d]\n",
+                  pms7003.getPM_1_0(),
+                  pms7003.getPM_1_0_atmos());              
+    Serial.print(output);
+    sprintf(output, "    PM2.5 (ug/m3): %2d     [atmos: %d]\n",
+                  pms7003.getPM_2_5(),
+                  pms7003.getPM_2_5_atmos());
+    Serial.print(output);
+    sprintf(output, "    PM10  (ug/m3): %2d     [atmos: %d]\n",
+                  pms7003.getPM_10_0(),
+                  pms7003.getPM_10_0_atmos());              
+    Serial.print(output);
+
+    sprintf(output, "\n    RAW: %2d[>0.3] %2d[>0.5] %2d[>1.0] %2d[>2.5] %2d[>5.0] %2d[>10]\n",
+                  pms7003.getRawGreaterThan_0_3(),
+                  pms7003.getRawGreaterThan_0_5(),
+                  pms7003.getRawGreaterThan_1_0(),
+                  pms7003.getRawGreaterThan_2_5(),
+                  pms7003.getRawGreaterThan_5_0(),
+                  pms7003.getRawGreaterThan_10_0());
+    Serial.print(output);
+
+
+  }
+
+
+}
+
+
+
+
+
+
+


### PR DESCRIPTION
The existing example does not work on Uno R3: it lacks `Serial1` port.

Moreover, even if I try to correct the example, I would not be able to compile this lib for Uno R3 because the default init method calls `Serial1` (which Uno R3 lacks).

Removing the default `init` with `Serial1` allows this library to be flexible and support all Arduino's - those that have multiple serial ports and those that only have one. 

Also added the Uno R3 specific example with `SoftwareSerial.h`